### PR TITLE
Add a coercing function of boolean

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -70,6 +70,16 @@
         (catch #?(:clj Exception
                   :cljs js/Error) _)))))
 
+(defn as-boolean
+  "Returns a boolean represented by s. as-boolean returns true if s is \"true\"
+  or \"yes\", ignoring case, false if \"false\" or \"no\", and nil otherwise."
+  [s]
+  (if-not (nil? s)
+    (condp re-matches s
+      #"(?i)(true|yes)" true
+      #"(?i)(false|no)" false
+      nil)))
+
 ;;; type check
 
 (defn is-uuid?

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -58,6 +58,19 @@
     (is (nil? (core/as-double "")))
     (is (nil? (core/as-double nil))))
 
+  (testing "as-boolean"
+    (is (true? (core/as-boolean "true")))
+    (is (true? (core/as-boolean "True")))
+    (is (true? (core/as-boolean "yes")))
+    (is (true? (core/as-boolean "YES")))
+    (is (false? (core/as-boolean "false")))
+    (is (false? (core/as-boolean "False")))
+    (is (false? (core/as-boolean "no")))
+    (is (false? (core/as-boolean "NO")))
+    (is (nil? (core/as-boolean "0")))
+    (is (nil? (core/as-boolean "")))
+    (is (nil? (core/as-boolean nil))))
+
   (testing "is-uuid?"
     (is (not (core/is-uuid? 1)))
     (is (not (core/is-uuid? "abc")))


### PR DESCRIPTION
Adds `as-boolean`. This function is different from [`Boolean/parseBoolean`](https://docs.oracle.com/javase/7/docs/api/java/lang/Boolean.html#parseBoolean(java.lang.String)) in that it

* also supports "Yes" and "No"
* returns `nil` if an illegal string is passed (`Boolean/parseBoolean` returns `false` in that case).

I feel this behavior is strict and useful.