### PR TITLE
Add a coercing function of rational

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -70,6 +70,23 @@
         (catch #?(:clj Exception
                   :cljs js/Error) _)))))
 
+(defn as-rational
+  "Returns a new rational number initialized to the value represented by s such
+  as \"1\", \"1/2\", and \"-1/2\". as-rational returns nil if s is an illegal
+  string, nil, or division by zero."
+  [s]
+  (if-not (nil? s)
+    (if-let [[_ n _ d] (re-matches #"([\-\+]?\d+)(/(\d+))?" (sanitize-number-string s))]
+      (try
+        (let [numerator (as-long n)
+              denominator (as-long d)]
+          (if denominator
+            (if (pos? denominator)
+              (/ numerator denominator))
+            numerator))
+        (catch #?(:clj Exception
+                  :cljs js/Error) _)))))
+
 (defn as-boolean
   "Returns a boolean represented by s. as-boolean returns true if s is \"true\"
   or \"yes\", ignoring case, false if \"false\" or \"no\", and nil otherwise."

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -58,6 +58,26 @@
     (is (nil? (core/as-double "")))
     (is (nil? (core/as-double nil))))
 
+  (testing "as-rational"
+    (is (= (core/as-rational "1") 1))
+    (is (= (core/as-rational "-1") -1))
+    (is (= (core/as-rational "1/2") #?(:clj 1/2
+                                       :cljs 0.5)))
+    (is (= (core/as-rational "-1/2") #?(:clj -1/2
+                                        :cljs -0.5)))
+    (is (= (core/as-rational "2/1") 2))
+    (is (zero? (core/as-rational "0")))
+    (is (zero? (core/as-rational "0/2")))
+    (is (= (core/as-rational "1,000/2,000") #?(:clj 1/2
+                                               :cljs 0.5)))
+    (is (nil? (core/as-rational "2/")))
+    (is (nil? (core/as-rational "/2")))
+    (is (nil? (core/as-rational "abc")))
+    (is (nil? (core/as-rational "")))
+    (is (nil? (core/as-rational nil)))
+    (is (nil? (core/as-rational "2/0")))
+    (is (nil? (core/as-rational "-2/0"))))
+
   (testing "as-boolean"
     (is (true? (core/as-boolean "true")))
     (is (true? (core/as-boolean "True")))


### PR DESCRIPTION
Adds `as-rational`, which parses a rational number string, such as "1" and "1/2", and returns a Long or Ratio. cljs version returns Float instead of Ratio because current ClojureScript [does not support Ratio](https://clojurescript.org/about/differences#_the_reader).