### PR TITLE
Add string pruning function

### DIFF
--- a/src/cljc/proton/string.cljc
+++ b/src/cljc/proton/string.cljc
@@ -1,0 +1,22 @@
+(ns proton.string
+  "String utilities.")
+
+(defn prune
+  "Returns pruned string that is shortened to the certain length and added dots.
+  The leaving side can be selected from :left, :right, or :both."
+  ([s] (prune s 10))
+  ([s len] (prune s len :left))
+  ([s len side] (prune s len side "..."))
+  ([s len side dots]
+   {:pre [(>= len (count dots))]}
+   (let [n (count s)
+         m (count dots)]
+     (if (> n len)
+       (apply str (case side
+                    :left [(subs s 0 (- len m)) dots]
+                    :right [dots (subs s (+ (- n len) m))]
+                    :both (let [l (/ (- len m) 2)
+                                sl (Math/ceil l)
+                                el (Math/floor l)]
+                            [(subs s 0 sl) dots (subs s (- n el))])))
+       s))))

--- a/test/proton/string_test.cljc
+++ b/test/proton/string_test.cljc
@@ -1,0 +1,26 @@
+(ns proton.string-test
+  (:require #?(:clj [clojure.test :refer [are deftest is testing]]
+               :cljs [cljs.test :refer-macros [are deftest is testing]])
+            [proton.string :as string]))
+
+(deftest prune-test
+  (testing "prune"
+    (are [args e] (= (apply string/prune args) e)
+      ["Simple made easy"] "Simple ..."
+      ["Simple made easy" 15] "Simple made ..."
+      ["Simple made easy" 3] "..."
+      ["Simple made easy" 10 :left] "Simple ..."
+      ["Simple made easy" 10 :right] "...de easy"
+      ["Simple made easy" 10 :both] "Simp...asy"
+      ["Simple made easy" 9 :left "!!!"] "Simple!!!"))
+  (testing "not prune"
+    (are [args] (= (apply string/prune args) (first args))
+      ["Simple"]
+      [""]
+      [nil]
+      ["Simple made easy" 20]))
+  (testing "error"
+    (are [args] (thrown? #?(:clj Throwable, :cljs js/Error) (apply string/prune args))
+      ["Simple made easy" 2]
+      ["Simple made easy" 10 :front]
+      ["Simple made easy" 3 :left "......"])))

--- a/test/proton/test.cljs
+++ b/test/proton/test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test]
             [proton.core-test]
             [proton.pattern-test]
+            [proton.string-test]
             ;; [proton.time-test]
             [proton.uri-test]))
 


### PR DESCRIPTION
Adds `proton.string` namespace and `proton.string/prune` function. `prune` is useful to shorten a long text with indicating the text is omitted.