### PR TITLE
Add number clipping function

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -171,3 +171,16 @@
           (aset result (quot i 2) (unchecked-byte v))
           (recur (+ i 2)))))
     result))
+
+;;; math
+
+(defn clip
+  "Limits x in the interval of [xmin xmax]. A value smaller than xmin becomes
+  xmin, and a value larger than xmax becomes xmax. If nil is supplied to
+  xmin/xmax, its side will not be limited."
+  [x xmin xmax]
+  {:pre [(some? x)
+         (or (some nil? [xmin xmax]) (<= xmin xmax))]}
+  (cond-> x
+    xmin (max xmin)
+    xmax (min xmax)))

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -1,6 +1,6 @@
 (ns proton.core-test
-  (:require #?(:clj [clojure.test :refer [deftest is testing]]
-               :cljs [cljs.test :refer-macros [deftest is testing]])
+  (:require #?(:clj [clojure.test :refer [deftest is are testing]]
+               :cljs [cljs.test :refer-macros [deftest is are testing]])
             [proton.core :as core]))
 
 (def example-hash "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30")
@@ -104,4 +104,17 @@
     (is (= example-hash
            (-> example-hash
                core/hex->bytes
-               core/bytes->hex)))))
+               core/bytes->hex))))
+
+  (testing "clip"
+    (are [x xmin xmax e] (= (core/clip x xmin xmax) e)
+      5 3   7   5
+      5 6   7   6
+      5 3   4   4
+      5 3   3   3
+      5 nil 7   5
+      5 3   nil 5
+      5 nil nil 5)
+    (are [x xmin xmax] (thrown? #?(:clj Throwable, :cljs js/Error) (core/clip x xmin xmax))
+      5 3 1
+      nil 3 7)))


### PR DESCRIPTION
Adds `proton.core/clip` function, which limits a number in a range of [min max].

```clojure
(clip 5 7 9)
;;=> 7

(clip 5 1 3)
;;=> 3
```

`clip` is useful for preventing an illegal number such as a negative value and a
too large value. This process is trivial, but it is often appeared.

The name `clip` comes from `numpy.clip`, which has similar function.