### PR TITLE
as-int should use proton.core/as-long upon NumberFormatException

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -36,7 +36,7 @@
              :cljs (let [r (js/parseInt n)]
                      (if (js/isNaN r) nil r)))
           #?(:clj (catch NumberFormatException e
-                    (Long/parseLong n)))
+                    (as-long n)))
           (catch #?(:clj Exception
                     :cljs js/Object) e nil))))))
 

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -14,6 +14,7 @@
     (is (= (core/as-int "12,345,678") 12345678))
     (is (= (core/as-int "-45") -45))
     (is (= (core/as-int "+67") 67))
+    (is (= (core/as-int "292999988888999999888888") nil))
     (is (= (core/as-int "abc") nil))
     (is (= (core/as-int "") nil))
     (is (= (core/as-int nil) nil)))


### PR DESCRIPTION
### problem

`(proton/as-int "292999988888999999888888")`
Results in a NumberFormatException, breaking the promise in the docstring

> as-int returns nil if s is an illegal string