### PR TITLE
Refactoring test code

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -10,7 +10,7 @@
       (string/replace #"," "")))
 
 (defn as-long
-  "Returns a new long number initialized o the value represented by s.
+  "Returns a new long number initialized to the value represented by s.
   as-int returns nil if s is an illegal string or nil."
   [s]
   (if-not (nil? s)
@@ -24,8 +24,8 @@
                     :cljs js/Object) e nil))))))
 
 (defn as-int
-  "Returns a new integer number initialized o the value represented by s.
-  as-int returns nil if s is an illegal string or nil. as-log returns a
+  "Returns a new integer number initialized to the value represented by s.
+  as-int returns nil if s is an illegal string or nil. as-long returns a
   long number if s is out of int range."
   [s]
   (if-not (nil? s)

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -1,121 +1,122 @@
 (ns proton.core-test
-  (:require #?(:clj [clojure.test :refer [deftest is are testing]]
-               :cljs [cljs.test :refer-macros [deftest is are testing]])
+  (:require #?(:clj [clojure.test :refer [deftest is are]]
+               :cljs [cljs.test :refer-macros [deftest is are]])
             [proton.core :as core]))
+
+(deftest as-long-test
+  (are [s e] (= (core/as-long s) e)
+    "0"          0
+    "123"        123
+    "999999999"  999999999
+    "12,345,678" 12345678
+    "-45"        -45
+    "+67"        67)
+  (are [s] (nil? (core/as-long s))
+    "abc"
+    ""
+    nil))
+
+(deftest as-int-test
+  (are [s e] (= (core/as-int s) e)
+    "0"          0
+    "123"        123
+    "999999999"  999999999
+    "12,345,678" 12345678
+    "-45"        -45
+    "+67"        67)
+  (are [s] (nil? (core/as-int s))
+    "292999988888999999888888"
+    "abc"
+    ""
+    nil))
+
+(deftest as-double-test
+  (are [s e] (= (core/as-double s) e)
+    "0"        0.0
+    "0.123"    0.123
+    "-3.45"    -3.45
+    "+5.67"    5.67
+    "-1.2e-5"  -1.2e-5
+    "4,321.23" 4321.23)
+  (are [s] (nil? (core/as-double s))
+    "1.23.45"
+    "abc"
+    ""
+    nil))
+
+(deftest as-float-test
+  (are [s e] (= (core/as-float s) e)
+    "0"        #?(:clj (float 0.0)     :cljs 0.0)
+    "0.123"    #?(:clj (float 0.123)   :cljs 0.123)
+    "-3.45"    #?(:clj (float -3.45)   :cljs -3.45)
+    "+5.67"    #?(:clj (float 5.67)    :cljs 5.67)
+    "-1.2e-5"  #?(:clj (float -1.2e-5) :cljs -1.2e-5)
+    "4,321.23" #?(:clj (float 4321.23) :cljs 4321.23))
+  (are [s] (nil? (core/as-float s))
+    "abc"
+    ""
+    nil))
+
+(deftest as-rational-test
+  (are [s e] (= (core/as-rational s) e)
+    "1"           1
+    "-1"          -1
+    "1/2"         #?(:clj 1/2 :cljs 0.5)
+    "-1/2"        #?(:clj -1/2 :cljs -0.5)
+    "2/1"         2
+    "0"           0
+    "0/2"         0
+    "1,000/2,000" #?(:clj 1/2 :cljs 0.5))
+  (are [s] (nil? (core/as-rational s))
+    "2/"
+    "/2"
+    "abc"
+    ""
+    nil
+    "2/0"
+    "-2/0"))
+
+(deftest as-boolean-test
+  (are [s] (true? (core/as-boolean s))
+    "true"
+    "True"
+    "yes"
+    "YES")
+  (are [s] (false? (core/as-boolean s))
+    "false"
+    "False"
+    "no"
+    "NO")
+  (are [s] (nil? (core/as-boolean s))
+    "0"
+    ""
+    nil))
+
+(deftest is-uuid?-test
+  (is (not (core/is-uuid? 1)))
+  (is (not (core/is-uuid? "abc")))
+  (is (core/is-uuid? #uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")))
+
+(deftest random-string-test
+  (is (= (count (core/random-string 8)) 8))
+  (is (not= (core/random-string 40) (core/random-string 40))))
 
 (def example-hash "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30")
 
-(deftest core-test
+(deftest bytes-test
+  (is (= example-hash (-> example-hash
+                          core/hex->bytes
+                          core/bytes->hex))))
 
-  (testing "as-int"
-    (is (= (core/as-int "0") 0))
-    (is (= (core/as-int "123") 123))
-    (is (= (core/as-int "999999999") 999999999))
-    (is (= (core/as-int "12,345,678") 12345678))
-    (is (= (core/as-int "-45") -45))
-    (is (= (core/as-int "+67") 67))
-    (is (= (core/as-int "292999988888999999888888") nil))
-    (is (= (core/as-int "abc") nil))
-    (is (= (core/as-int "") nil))
-    (is (= (core/as-int nil) nil)))
-
-  (testing "as-long"
-    (is (= (core/as-long "0") 0))
-    (is (= (core/as-long "123") 123))
-    (is (= (core/as-long "999999999") 999999999))
-    (is (= (core/as-long "12,345,678") 12345678))
-    (is (= (core/as-long "-45") -45))
-    (is (= (core/as-long "+67") 67))
-    (is (= (core/as-long "abc") nil))
-    (is (= (core/as-long "") nil))
-    (is (= (core/as-long nil) nil)))
-
-  (testing "as-float"
-    (is (= (core/as-float "0") #?(:clj (float 0.0)
-                                  :cljs 0.0)))
-    (is (= (core/as-float "0.123") #?(:clj (float 0.123)
-                                      :cljs 0.123)))
-    (is (= (core/as-float "-3.45") #?(:clj (float -3.45)
-                                      :cljs -3.45)))
-    (is (= (core/as-float "+5.67") #?(:clj (float 5.67)
-                                      :cljs 5.67)))
-    (is (= (core/as-float "-1.2e-5") #?(:clj (float -1.2e-5)
-                                        :cljs -1.2e-5)))
-    (is (= (core/as-float "4,321.23") #?(:clj (float 4321.23)
-                                         :cljs 4321.23)))
-    (is (nil? (core/as-float "abc")))
-    (is (nil? (core/as-float "")))
-    (is (nil? (core/as-float nil))))
-
-  (testing "as-double"
-    (is (= (core/as-double "0") 0.0))
-    (is (= (core/as-double "0.123") 0.123))
-    (is (= (core/as-double "-3.45") -3.45))
-    (is (= (core/as-double "+5.67") 5.67))
-    (is (= (core/as-double "-1.2e-5") -1.2e-5))
-    (is (= (core/as-double "4,321.23") 4321.23))
-    (is (nil? (core/as-double "1.23.45")))
-    (is (nil? (core/as-double "abc")))
-    (is (nil? (core/as-double "")))
-    (is (nil? (core/as-double nil))))
-
-  (testing "as-rational"
-    (is (= (core/as-rational "1") 1))
-    (is (= (core/as-rational "-1") -1))
-    (is (= (core/as-rational "1/2") #?(:clj 1/2
-                                       :cljs 0.5)))
-    (is (= (core/as-rational "-1/2") #?(:clj -1/2
-                                        :cljs -0.5)))
-    (is (= (core/as-rational "2/1") 2))
-    (is (zero? (core/as-rational "0")))
-    (is (zero? (core/as-rational "0/2")))
-    (is (= (core/as-rational "1,000/2,000") #?(:clj 1/2
-                                               :cljs 0.5)))
-    (is (nil? (core/as-rational "2/")))
-    (is (nil? (core/as-rational "/2")))
-    (is (nil? (core/as-rational "abc")))
-    (is (nil? (core/as-rational "")))
-    (is (nil? (core/as-rational nil)))
-    (is (nil? (core/as-rational "2/0")))
-    (is (nil? (core/as-rational "-2/0"))))
-
-  (testing "as-boolean"
-    (is (true? (core/as-boolean "true")))
-    (is (true? (core/as-boolean "True")))
-    (is (true? (core/as-boolean "yes")))
-    (is (true? (core/as-boolean "YES")))
-    (is (false? (core/as-boolean "false")))
-    (is (false? (core/as-boolean "False")))
-    (is (false? (core/as-boolean "no")))
-    (is (false? (core/as-boolean "NO")))
-    (is (nil? (core/as-boolean "0")))
-    (is (nil? (core/as-boolean "")))
-    (is (nil? (core/as-boolean nil))))
-
-  (testing "is-uuid?"
-    (is (not (core/is-uuid? 1)))
-    (is (not (core/is-uuid? "abc")))
-    (is (core/is-uuid? #uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")))
-
-  (testing "random-string"
-    (is (= (count (core/random-string 8)) 8))
-    (is (not= (core/random-string 40) (core/random-string 40))))
-
-  (testing "bytes"
-    (is (= example-hash
-           (-> example-hash
-               core/hex->bytes
-               core/bytes->hex))))
-
-  (testing "clip"
-    (are [x xmin xmax e] (= (core/clip x xmin xmax) e)
-      5 3   7   5
-      5 6   7   6
-      5 3   4   4
-      5 3   3   3
-      5 nil 7   5
-      5 3   nil 5
-      5 nil nil 5)
-    (are [x xmin xmax] (thrown? #?(:clj Throwable, :cljs js/Error) (core/clip x xmin xmax))
-      5 3 1
-      nil 3 7)))
+(deftest clip-test
+  (are [x xmin xmax e] (= (core/clip x xmin xmax) e)
+    5 3   7   5
+    5 6   7   6
+    5 3   4   4
+    5 3   3   3
+    5 nil 7   5
+    5 3   nil 5
+    5 nil nil 5)
+  (are [x xmin xmax] (thrown? #?(:clj Throwable :cljs js/Error) (core/clip x xmin xmax))
+    5   3 1
+    nil 3 7))

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -1,6 +1,6 @@
 (ns proton.core-test
-  (:require #?(:clj [clojure.test :refer [deftest is are]]
-               :cljs [cljs.test :refer-macros [deftest is are]])
+  (:require #?(:clj [clojure.test :refer [deftest is are testing]]
+               :cljs [cljs.test :refer-macros [deftest is are testing]])
             [proton.core :as core]))
 
 (deftest as-long-test
@@ -14,7 +14,10 @@
   (are [s] (nil? (core/as-long s))
     "abc"
     ""
-    nil))
+    nil)
+  (testing "different between clj and cljs"
+    (is (= (core/as-long "292999988888999999888888")
+           #?(:clj nil :cljs 292999988888999999888888)))))
 
 (deftest as-int-test
   (are [s e] (= (core/as-int s) e)
@@ -25,10 +28,12 @@
     "-45"        -45
     "+67"        67)
   (are [s] (nil? (core/as-int s))
-    "292999988888999999888888"
     "abc"
     ""
-    nil))
+    nil)
+  (testing "different between clj and cljs"
+    (is (= (core/as-int "292999988888999999888888")
+           #?(:clj nil :cljs 292999988888999999888888)))))
 
 (deftest as-double-test
   (are [s e] (= (core/as-double s) e)

--- a/test/proton/pattern_test.cljc
+++ b/test/proton/pattern_test.cljc
@@ -1,50 +1,45 @@
 (ns proton.pattern-test
-  (:require #?(:clj [clojure.test :refer [deftest is testing]]
-               :cljs [cljs.test :refer-macros [deftest is testing]])
+  (:require #?(:clj [clojure.test :refer [deftest is are testing]]
+               :cljs [cljs.test :refer-macros [deftest is are testing]])
             [proton.pattern :as pattern]))
 
-(deftest pattern-test
+(deftest valid-email?-test
+  (testing "valid"
+    (are [s] (pattern/valid-email? s)
+      "test@example.com"
+      "a@abc.jp" ; short
+      "test+!&-_=?@example.com" ; including symbol chars
+      "test..@example.com" ; not valid (violation rfc), but should allow for japanese moby
+      ))
+  (testing "invalid"
+    (are [s] (not (pattern/valid-email? s))
+      nil
+      "" ; empty
+      "example" ; only local-part
+      "example.com" ; only domain-part
+      "test_example.com" ; @ not found
+      "test@example.com " ; extra spaced mail-address
+      "<test@example.com>" ; valid value of "From:" header, but not valid mail-address
+      "\"test\"@example.com" ; valid, but it disturb consistency check, so may not allow this
+      "test%example.com" ; valid, but should not allow this! These are "source routing".
+      "test%example.org@example.com")))
 
-  (testing "valid-email?"
-    (is (not (pattern/valid-email? nil)))
-    ;; empty
-    (is (not (pattern/valid-email? "")))
-    ;; only local-part
-    (is (not (pattern/valid-email? "example")))
-    ;; only domain-part
-    (is (not (pattern/valid-email? "example.com")))
-    ;; valid short mail-address
-    (is (pattern/valid-email? "a@abc.jp"))
-    ;; valid mail-address
-    (is (pattern/valid-email? "test@example.com"))
-    ;; @ not found
-    (is (not (pattern/valid-email? "test_example.com")))
-    ;; extra spaced mail-address
-    (is (not (pattern/valid-email? "test@example.com ")))
-    ;; valid mail-address include symbol chars
-    (is (pattern/valid-email? "test+!&-_=?@example.com"))
-    ;; It's not valid(violation rfc), but it should allow for japanese moby
-    (is (pattern/valid-email? "test..@example.com"))
-    ;; It's valid value of "From:" header, but not valid mail-address
-    (is (not (pattern/valid-email? "<test@example.com>")))
-    ;; It's valid, but it disturb consistency check, so may not allow this
-    (is (not (pattern/valid-email? "\"test\"@example.com")))
-    ;; It's valid, but should not allow this! These are "source routing".
-    (is (not (pattern/valid-email? "test%example.com")))
-    (is (not (pattern/valid-email? "test%example.org@example.com"))))
+(deftest valid-password?-test
+  (testing "valid"
+    (are [s] (pattern/valid-password? s)
+      "1234abcd"
+      "ABCD!@#$"
+      "%^&*()_+"
+      "<>\\\"'"))
+  (testing "invalid"
+    (are [s] (not (pattern/valid-password? s))
+      nil
+      ""
+      "password "
+      "password\n"
+      "password\t")))
 
-  (testing "valid-password?"
-    (is (not (pattern/valid-password? nil)))
-    (is (not (pattern/valid-password? "")))
-    (is (pattern/valid-password? "1234abcd"))
-    (is (pattern/valid-password? "ABCD!@#$"))
-    (is (pattern/valid-password? "%^&*()_+"))
-    (is (pattern/valid-password? "<>\\\"'"))
-    (is (not (pattern/valid-password? "password ")))
-    (is (not (pattern/valid-password? "password\n")))
-    (is (not (pattern/valid-password? "password\t"))))
-
-  (testing "valid-uuid?"
-    (is (not (pattern/valid-uuid? nil)))
-    (is (not (pattern/valid-uuid? "")))
-    (is (pattern/valid-uuid? "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))))
+(deftest valid-uuid?-test
+  (is (not (pattern/valid-uuid? nil)))
+  (is (not (pattern/valid-uuid? "")))
+  (is (pattern/valid-uuid? "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")))

--- a/test/proton/test.cljs
+++ b/test/proton/test.cljs
@@ -1,5 +1,6 @@
 (ns proton.test
   (:require [cljs.test]
+            [goog.object :as gobj]
             [proton.core-test]
             [proton.pattern-test]
             [proton.string-test]
@@ -7,6 +8,15 @@
             [proton.uri-test]))
 
 (enable-console-print!)
+
+(defn- exit
+  [status]
+  (if-let [nodejs-exit (and (exists? js/process) (gobj/get js/process "exit"))]
+    (nodejs-exit status)
+    (println "Exit function not found")))
+
+(defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
+  (exit (if (cljs.test/successful? m) 0 1)))
 
 (defn -main
   [& args]

--- a/test/proton/time_test.cljc
+++ b/test/proton/time_test.cljc
@@ -1,11 +1,9 @@
 (ns proton.time-test
-  (:require #?(:clj [clojure.test :refer [deftest is testing]]
-               :cljs [cljs.test :refer-macros [deftest is testing]])
+  (:require #?(:clj [clojure.test :refer [deftest is]]
+               :cljs [cljs.test :refer-macros [deftest is]])
             [proton.time :as time]))
 
-(deftest time-test
-
-  (testing "datetime format"
-    (is (= (time/format-datetime-string (time/datetime-formatter "yyyy/MM/dd HH:mm:ss")
-                                        (time/datetime 1474361101))
-           "2016/09/20 08:45:01"))))
+(deftest datetime-format-test
+  (is (= (time/format-datetime-string (time/datetime-formatter "yyyy/MM/dd HH:mm:ss")
+                                      (time/datetime 1474361101))
+         "2016/09/20 08:45:01")))

--- a/test/proton/uri_test.cljc
+++ b/test/proton/uri_test.cljc
@@ -1,37 +1,37 @@
 (ns proton.uri-test
-  (:require #?(:clj [clojure.test :refer [deftest is testing]]
-               :cljs [cljs.test :refer-macros [deftest is testing]])
+  (:require #?(:clj [clojure.test :refer [deftest is are]]
+               :cljs [cljs.test :refer-macros [deftest is are]])
             [proton.uri :as uri]))
 
+(deftest uri-encode-test
+  (are [s e] (= (uri/uri-encode s) e)
+    nil nil
+    "" ""
+    "ABC" "ABC"
+    "テスト" "%E3%83%86%E3%82%B9%E3%83%88"))
+
+(deftest uri-decode-test
+  (are [s e] (= (uri/uri-decode s) e)
+    nil nil
+    "" ""
+    "XYZ" "XYZ"
+    "%E3%83%86%E3%82%B9%E3%83%88" "テスト"))
+
 (deftest uri-test
-
-  (testing "URI encode/decode"
-    ;; encoder
-    (is (= (uri/uri-encode nil) nil))
-    (is (= (uri/uri-encode "") ""))
-    (is (= (uri/uri-encode "ABC") "ABC"))
-    (is (= (uri/uri-encode "テスト") "%E3%83%86%E3%82%B9%E3%83%88"))
-    ;; decoder
-    (is (= (uri/uri-decode nil) nil))
-    (is (= (uri/uri-decode "") ""))
-    (is (= (uri/uri-decode "XYZ") "XYZ"))
-    (is (= (uri/uri-decode "%E3%83%86%E3%82%B9%E3%83%88") "テスト")))
-
-  (testing "URI parser"
-    (is (= (uri/uri) nil))
-    (is (= (uri/uri "http://localhost/path/to/file")
-           {:scheme "http"
-            :host "localhost"
-            :port nil
-            :path "/path/to/file"
-            :query nil
-            :fragment nil
-            :user-info nil}))
-    (is (= (uri/uri "https://user:pa55w0rd@example.com:3000/path/to/content?foo=1&bar=ABC&baz=%E3%83%86%E3%82%B9%E3%83%88#footer")
-           {:scheme "https"
-            :host "example.com"
-            :port 3000
-            :path "/path/to/content"
-            :query {:foo "1" :bar "ABC" :baz "テスト"}
-            :fragment "footer"
-            :user-info "user:pa55w0rd"}))))
+  (is (nil? (uri/uri)))
+  (is (= (uri/uri "http://localhost/path/to/file")
+         {:scheme "http"
+          :host "localhost"
+          :port nil
+          :path "/path/to/file"
+          :query nil
+          :fragment nil
+          :user-info nil}))
+  (is (= (uri/uri "https://user:pa55w0rd@example.com:3000/path/to/content?foo=1&bar=ABC&baz=%E3%83%86%E3%82%B9%E3%83%88#footer")
+         {:scheme "https"
+          :host "example.com"
+          :port 3000
+          :path "/path/to/content"
+          :query {:foo "1" :bar "ABC" :baz "テスト"}
+          :fragment "footer"
+          :user-info "user:pa55w0rd"})))


### PR DESCRIPTION
I refactored test code.

I split a `deftest` into multiple `deftest`, basically one `deftest` on one function. I feel that is more conventional.

Besides, I fixed exit status of ClojureScript test. `cljs.test/run-all-tests` always exits successfully even if a test fails. Actually, `(is (= (core/as-int "292999988888999999888888") nil))` failed on ClojureScript test because JS could parse it, but CI passed the [build](https://travis-ci.org/xcoo/proton/jobs/349726820#L658).

