### PR TITLE
Add position-based string splitting fn

### DIFF
--- a/src/cljc/proton/string.cljc
+++ b/src/cljc/proton/string.cljc
@@ -1,5 +1,7 @@
 (ns proton.string
-  "String utilities.")
+  "String utilities."
+  (:refer-clojure :exclude [split-at])
+  (:require [proton.core :as core]))
 
 (defn prune
   "Returns pruned string that is shortened to the certain length and added dots.
@@ -20,3 +22,21 @@
                                 el (Math/floor l)]
                             [(subs s 0 sl) dots (subs s (- n el))])))
        s))))
+
+(defn split-at
+  "Returns a vector of substrings split at the position. You can supply an
+  integer or list as the splitting position."
+  [s x]
+  (let [len (count s)
+        subs* (fn
+                ([s start] (subs s (core/clip start 0 len)))
+                ([s start end] (subs s (core/clip start 0 len) (core/clip end 0 len))))]
+    (cond
+      (integer? x) [(subs* s 0 x) (subs* s x)]
+      (sequential? x) (loop [[n & r] (cons 0 x), ret []]
+                        (if (seq r)
+                          (recur r (conj ret (subs* s n (first r))))
+                          (conj ret (subs* s n))))
+      :else (throw #?(:clj (IllegalArgumentException.
+                            "Splitting position should be an integer or list.")
+                      :cljs (js/Error. "Splitting position should be an integer or list."))))))

--- a/test/proton/string_test.cljc
+++ b/test/proton/string_test.cljc
@@ -24,3 +24,27 @@
       ["Simple made easy" 2]
       ["Simple made easy" 10 :front]
       ["Simple made easy" 3 :left "......"])))
+
+(deftest split-at-test
+  (testing "single splitting position"
+    (are [s x e] (= (string/split-at s x) e)
+      "clojure" 3  ["clo" "jure"]
+      "clojure" 0  ["" "clojure"]
+      "clojure" 7  ["clojure" ""]
+      "clojure" -1 ["" "clojure"]
+      "clojure" 8  ["clojure" ""]
+      ""        3  ["" ""]))
+  (testing "multiple splitting positions"
+    (are [s x e] (= (string/split-at s x) e)
+      "clojure" [3 5]  ["clo" "ju" "re"]
+      "clojure" [0 3]  ["" "clo" "jure"]
+      "clojure" [5 7]  ["cloju" "re" ""]
+      "clojure" [-1 3] ["" "clo" "jure"]
+      "clojure" [5 8]  ["cloju" "re" ""]
+      "clojure" []     ["clojure"]
+      ""        [3 5]  ["" "" ""]))
+  (testing "error"
+    (are [s x] (thrown? #?(:clj Throwable, :cljs js/Error) (string/split-at s x))
+      "clojure" "3"
+      "clojure" nil
+      nil       3)))


### PR DESCRIPTION
Adds `proton.string/split-at` function, which splits a string into multiple substrings based on a supplied position or positions.

```clj
(require '[proton.string :as pstring])

(pstring/split-at "clojure" 3)
;;=> ["clo" "jure"]

(pstring/split-at "clojure" [3 5])
;;=> ["clo" "ju" "re"]
```