### PR TITLE
Specify type hints for cljs

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -78,8 +78,8 @@
   (if-not (nil? s)
     (if-let [[_ n _ d] (re-matches #"([\-\+]?\d+)(/(\d+))?" (sanitize-number-string s))]
       (try
-        (let [numerator (as-long n)
-              denominator (as-long d)]
+        (let [numerator ^long (as-long n)
+              denominator ^long (as-long d)]
           (if denominator
             (if (pos? denominator)
               (/ numerator denominator))


### PR DESCRIPTION
ClojureScript 1.10.439 supports [function return type inference](https://clojurescript.org/news/2018-11-02-release#_function_return_type_inference), but it seems not to work on some fns, printing the following warnings.

```
WARNING: cljs.core/>, all arguments must be numbers, got [#{nil clj-nil} number] instead at line 84 /path/to/proton/src/cljc/proton/core.cljc
WARNING: cljs.core//, all arguments must be numbers, got [#{nil clj-nil} #{nil clj-nil}] instead at line 85 /path/to/proton/src/cljc/proton/core.cljc
```

I added type hints to avoid the warnings. The type hints are also enabled on clj, but it has no effect.