### PR TITLE
Move random-string fn to proton.string

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -110,7 +110,7 @@
 (def ^:private alphabet-ascii-codes (concat (range 48 58) (range 65 91) (range 97 123)))
 
 (defn ^:deprecated random-string
-  "DEPRECATED: Use 'proton.string/rand-string' instead.
+  "DEPRECATED: Use 'proton.string/rand-str' instead.
   Generate random string from alphabets and numbers (i.e. 0-9, A-Z, and a-z)"
   [length]
   (apply str (repeatedly length #(char (rand-nth alphabet-ascii-codes)))))

--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -109,8 +109,9 @@
 
 (def ^:private alphabet-ascii-codes (concat (range 48 58) (range 65 91) (range 97 123)))
 
-(defn random-string
-  "Generate random string from alphabets and numbers (i.e. 0-9, A-Z, and a-z)"
+(defn ^:deprecated random-string
+  "DEPRECATED: Use 'proton.string/rand-string' instead.
+  Generate random string from alphabets and numbers (i.e. 0-9, A-Z, and a-z)"
   [length]
   (apply str (repeatedly length #(char (rand-nth alphabet-ascii-codes)))))
 

--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -107,7 +107,7 @@
 
 ;;; random string
 
-(def ^:private alphabet-ascii-codes (concat (range 48 58) (range 66 91) (range 97 123)))
+(def ^:private alphabet-ascii-codes (concat (range 48 58) (range 65 91) (range 97 123)))
 
 (defn random-string
   "Generate random string from alphabets and numbers (i.e. 0-9, A-Z, and a-z)"

--- a/src/cljc/proton/string.cljc
+++ b/src/cljc/proton/string.cljc
@@ -40,3 +40,19 @@
       :else (throw #?(:clj (IllegalArgumentException.
                             "Splitting position should be an integer or list.")
                       :cljs (js/Error. "Splitting position should be an integer or list."))))))
+
+(def ^:private ascii-code-map
+  {:number (range 48 58)
+   :letter (concat (range 65 91) (range 97 123))
+   :upper-case-letter (range 65 91)
+   :lower-case-letter (range 97 123)})
+
+(defn rand-string
+  "Generates a random string of the certain length. The generated string
+  consists of numbers and letters (i.e. 0-9, A-Z, and a-z). You can change the
+  characters by supplying character types from :number, :letter,
+  :upper-case-letter, or :lower-case-letter."
+  [len & char-types]
+  (let [char-types (or char-types [:number :letter])
+        ascii-codes (distinct (mapcat ascii-code-map char-types))]
+    (apply str (repeatedly len #(char (rand-nth ascii-codes))))))

--- a/src/cljc/proton/string.cljc
+++ b/src/cljc/proton/string.cljc
@@ -47,7 +47,7 @@
    :upper-case-letter (range 65 91)
    :lower-case-letter (range 97 123)})
 
-(defn rand-string
+(defn rand-str
   "Generates a random string of the certain length. The generated string
   consists of numbers and letters (i.e. 0-9, A-Z, and a-z). You can change the
   characters by supplying character types from :number, :letter,

--- a/test/proton/string_test.cljc
+++ b/test/proton/string_test.cljc
@@ -48,3 +48,14 @@
       "clojure" "3"
       "clojure" nil
       nil       3)))
+
+(deftest rand-string-test
+  (let [s (string/rand-string 8)]
+    (is (string? s))
+    (is (= (count s) 8))
+    (is (re-matches #"[0-9A-Za-z]+" s)))
+  (is (re-matches #"[0-9]+" (string/rand-string 8 :number)))
+  (is (re-matches #"[0-9a-z]+" (string/rand-string 8 :number :lower-case-letter)))
+  (is (not= (string/rand-string 40) (string/rand-string 40)))
+  (is (= (string/rand-string 0) ""))
+  (is (= (string/rand-string -1) "")))

--- a/test/proton/string_test.cljc
+++ b/test/proton/string_test.cljc
@@ -49,13 +49,13 @@
       "clojure" nil
       nil       3)))
 
-(deftest rand-string-test
-  (let [s (string/rand-string 8)]
+(deftest rand-str-test
+  (let [s (string/rand-str 8)]
     (is (string? s))
     (is (= (count s) 8))
     (is (re-matches #"[0-9A-Za-z]+" s)))
-  (is (re-matches #"[0-9]+" (string/rand-string 8 :number)))
-  (is (re-matches #"[0-9a-z]+" (string/rand-string 8 :number :lower-case-letter)))
-  (is (not= (string/rand-string 40) (string/rand-string 40)))
-  (is (= (string/rand-string 0) ""))
-  (is (= (string/rand-string -1) "")))
+  (is (re-matches #"[0-9]+" (string/rand-str 8 :number)))
+  (is (re-matches #"[0-9a-z]+" (string/rand-str 8 :number :lower-case-letter)))
+  (is (not= (string/rand-str 40) (string/rand-str 40)))
+  (is (= (string/rand-str 0) ""))
+  (is (= (string/rand-str -1) "")))


### PR DESCRIPTION
I moved `proton.core/random-string` to `proton.string/rand-string` with character-type options.

```clj
(require '[proton.string :as pstring])

(pstring/rand-string 8)
;;=> "bonYIfi9"

(pstring/rand-string 8 :number :lower-case-letter)
;;=> "iw5tx9bk"
```

I think random-string fn should be located in `proton.string`, and `rand-string` is a bit better name because it is similar to `rand-int`.

I marked `proton.core/random-string` as deprecated. `proton.string/rand-string` maintains full compatibility with `proton.core/random-string`.

Besides, I fixed a bug of ascii codes of `proton.core/random-string`.
