### PR TITLE
add diff-u and diff-u=

### DIFF
--- a/src/cljc/proton/diff.cljc
+++ b/src/cljc/proton/diff.cljc
@@ -1,0 +1,38 @@
+(ns proton.diff
+  (:require
+   [clojure.data :refer [diff]]
+   [clojure.pprint :refer [pprint]]
+   [clojure.string :as string]))
+
+(defn- blank-padding [origin size]
+  (into origin (take size (repeat ""))))
+
+(defn- align-length [a-diff b-diff]
+  (let [ac (count a-diff)
+        bc (count b-diff)]
+    (case (compare ac bc)
+      1 [a-diff (blank-padding b-diff (- ac bc))]
+      -1 [(blank-padding a-diff (- bc ac)) b-diff]
+      [a-diff b-diff])))
+
+(defn diff-u
+  "Recursively compares a and b, returning a diff string in unified format (like `diff -u` command).
+   Comparison rules are same as clojure.data/diff"
+  [a b]
+  (if (every? #(or (nil? %) (map? %)) [a b])
+    (some->> (diff a b)
+             (take 2)
+             (map #(and % (-> (pprint %)
+                              with-out-str
+                              (string/split #"\n"))))
+             (apply align-length)
+             (#(apply map (fn [a b]
+                            (if (= a b)
+                              a
+                              (str "- " a "\n"
+                                   "+ " b))) %))
+             (seq)
+             (string/join "\n"))
+    (throw #?(:clj (IllegalArgumentException.
+                    "a and b should be nil or map.")
+              :cljs (js/Error. "a and b should be nil or map.")))))

--- a/src/cljc/proton/diff.cljc
+++ b/src/cljc/proton/diff.cljc
@@ -9,28 +9,32 @@
 
 (defn- align-length [a-diff b-diff]
   (let [ac (count a-diff)
-        bc (count b-diff)]
-    (case (compare ac bc)
-      1 [a-diff (blank-padding b-diff (- ac bc))]
-      -1 [(blank-padding a-diff (- bc ac)) b-diff]
-      [a-diff b-diff])))
+        bc (count b-diff)
+        compare-result (compare ac bc)]
+    (cond
+      (pos? compare-result) [a-diff (blank-padding b-diff (- ac bc))]
+      (neg? compare-result) [(blank-padding a-diff (- bc ac)) b-diff]
+      :else [a-diff b-diff])))
+
+(defn- diffs->str [diffs]
+  (apply map (fn [a b]
+               (if (= a b)
+                 a
+                 (str "- " a "\n"
+                      "+ " b))) diffs))
 
 (defn diff-u
   "Recursively compares a and b, returning a diff string in unified format (like `diff -u` command).
    Comparison rules are same as clojure.data/diff"
   [a b]
-  (if (every? #(or (nil? %) (map? %)) [a b])
+  (if (every? (some-fn nil? map?) [a b])
     (some->> (diff a b)
              (take 2)
              (map #(and % (-> (pprint %)
                               with-out-str
                               (string/split #"\n"))))
              (apply align-length)
-             (#(apply map (fn [a b]
-                            (if (= a b)
-                              a
-                              (str "- " a "\n"
-                                   "+ " b))) %))
+             (diffs->str)
              (seq)
              (string/join "\n"))
     (throw #?(:clj (IllegalArgumentException.

--- a/src/cljc/proton/diff_assert.cljc
+++ b/src/cljc/proton/diff_assert.cljc
@@ -1,6 +1,6 @@
 (ns proton.diff-assert
   (:require #?(:clj [clojure.test :refer [assert-expr do-report]]
-               :cljs [cljs.test :refer-macros [assert-expr do-report]])
+               :cljs [cljs.test :refer-macros [assert-expr] :refer [do-report]])
             [proton.diff :as diff]))
 
 (defmethod assert-expr 'diff-u= [msg form]

--- a/src/cljc/proton/diff_assert.cljc
+++ b/src/cljc/proton/diff_assert.cljc
@@ -1,0 +1,15 @@
+(ns proton.diff-assert
+  (:require #?(:clj [clojure.test :refer [assert-expr do-report]]
+               :cljs [cljs.test :refer-macros [assert-expr do-report]])
+            [proton.diff :as diff]))
+
+(defmethod assert-expr 'diff-u= [msg form]
+  `(let [actual# ~(nth form 1)
+         expected# ~(nth form 2)
+         diff# (diff/diff-u actual# expected#)]
+     (if diff#
+       (do-report {:type :fail :message diff#
+                   :expected expected# :actual actual#})
+       (do-report {:type :pass :message ~msg
+                   :expected expected# :actual actual#}))
+     (not diff#)))

--- a/test/proton/diff_assert_test.cljc
+++ b/test/proton/diff_assert_test.cljc
@@ -1,0 +1,8 @@
+(ns proton.diff-assert-test
+  (:require #?(:clj [clojure.test :refer [is deftest testing]]
+               :cljs [cljs.test :refer-macros [is deftest testing]])
+            [proton.diff-assert]))
+
+(deftest diff-assert-test
+  (testing "diff-u= assert"
+    (is (diff-u= {:a 1} {:a 1}))))

--- a/test/proton/diff_assert_test.cljc
+++ b/test/proton/diff_assert_test.cljc
@@ -1,7 +1,8 @@
 (ns proton.diff-assert-test
-  (:require #?(:clj [clojure.test :refer [is deftest testing]]
-               :cljs [cljs.test :refer-macros [is deftest testing]])
-            [proton.diff-assert]))
+  #?(:clj (:require [clojure.test :refer [is deftest testing]]
+                    [proton.diff-assert])
+     :cljs (:require-macros [cljs.test :refer [is deftest testing]]
+                            [proton.diff-assert])))
 
 (deftest diff-assert-test
   (testing "diff-u= assert"

--- a/test/proton/diff_test.cljc
+++ b/test/proton/diff_test.cljc
@@ -1,0 +1,25 @@
+(ns proton.diff-test
+  (:require #?(:clj [clojure.test :refer [are deftest testing]]
+               :cljs [cljs.test :refer-macros [are deftest testing]])
+            [proton.diff :as diff]))
+
+(deftest diff-u-test
+  (testing "diff -u"
+    (are [a b e] (= (diff/diff-u a b) e)
+      nil nil nil
+      nil {} "- \n+ {}"
+      {} nil "- {}\n+ "
+      {} {} nil
+      {} {:a 1} "- \n+ {:a 1}"
+      {:a 1} {} "- {:a 1}\n+ "
+      nil {:a 1} "- \n+ {:a 1}"
+      {:a 1} nil "- {:a 1}\n+ "
+      {:a 1} {:a 1} nil
+      {:a 1} {:b 2} "- {:a 1}\n+ {:b 2}"
+      {:a 1} {:a 1 :b 2} "- \n+ {:b 2}"
+      {:a 1 :b 2} {:a 1} "- {:b 2}\n+ "))
+  (testing "error"
+    (are [a b] (thrown? #?(:clj Throwable, :cljs js/Error) (diff/diff-u a b))
+      [] []
+      nil []
+      [] nil)))


### PR DESCRIPTION
I created `diff-u` function and `diff-u=` assertion.

### diff-u

You can get a difference string between two maps, like `diff -u` command.

```clojure
user=> (require '[proton.diff :as diff])
nil
user=> (println (diff/diff-u {:a {:b {:c 1 :d 2 :e 3}}} {:a {:b {:c 1 :d 2 :e 4}}}))
- {:a {:b {:e 3}}}
+ {:a {:b {:e 4}}}
nil
```

### diff-u=

You can use this in `is` macro as same as `=`. 
However, when the test is failure, you can see the error message in `diff-u` format.

For example:

```clojure
(ns proton.diff-assert-test
  (:require #?(:clj [clojure.test :refer [is deftest testing]]
               :cljs [cljs.test :refer-macros [is deftest testing]])
            [proton.diff-assert]))

(deftest diff-assert-test
  (testing "diff-u= assert"
    (is (diff-u= {:a 1 :b 1} {:a 1}))))
```

This test fails like this:

```
FAIL in (diff-assert-test) (diff_assert_test.cljc:8)
diff-u= assert
- {:b 1}
+ 
expected: {:a 1}
  actual: {:a 1, :b 1}

Ran 1 tests containing 1 assertions.
1 failures, 0 errors.
Tests failed.
```
