### PR TITLE
Add assoc-in-after function

### DIFF
--- a/src/cljc/proton/assoc_in_after.cljc
+++ b/src/cljc/proton/assoc_in_after.cljc
@@ -1,0 +1,39 @@
+(ns proton.assoc-in-after
+  "Functions of `assoc-in` in a specific position")
+
+(defn- contains-in? [m ks]
+  (contains? (get-in m (butlast ks)) (last ks)))
+
+(defn- assoc-in* [m ks v]
+  (if (empty? ks)
+    v
+    (assoc-in m ks v)))
+
+(defn assoc-in-after
+  "Inserts `v` into `ks` after `before-ks` in `omap`"
+  [omap ks v before-ks]
+  (cond
+    (empty? ks) v
+    (empty? before-ks) (assoc-in* omap ks v)
+    (contains-in? omap ks) (assoc-in* omap ks v)
+    (contains? omap (first ks)) (update omap
+                                        (first ks)
+                                        assoc-in-after
+                                        (rest ks)
+                                        v
+                                        (rest before-ks))
+    (= ::first (first before-ks)) (into (array-map)
+                                        (cons [(first ks)
+                                               (assoc-in* (array-map)
+                                                          (rest ks)
+                                                          v)]
+                                              (seq omap)))
+    (not (contains? omap (first before-ks))) (assoc-in* omap ks v)
+    :else (into (array-map)
+                (mapcat (fn [[k child]]
+                          (if (= (first before-ks) k)
+                            [[k child]
+                             [(first ks)
+                              (assoc-in* (array-map) (rest ks) v)]]
+                            [[k child]]))
+                        (seq omap)))))

--- a/src/cljc/proton/assoc_in_after.cljc
+++ b/src/cljc/proton/assoc_in_after.cljc
@@ -15,7 +15,7 @@
 `array-map` cannot keep the order when there are many elements, so in that case, please consider using `ordered-map` etc.
 `v` is new value, `ks` and `before-ks` are sequences of keys."
   [omap ks v before-ks]
-  (let [empty-omap (empty omap)]
+  (let [empty-omap (with-meta (empty omap) nil)]
     (cond
       (empty? ks) v
       (empty? before-ks) (assoc-in* omap ks v)

--- a/src/cljc/proton/assoc_in_after.cljc
+++ b/src/cljc/proton/assoc_in_after.cljc
@@ -10,7 +10,10 @@
     (assoc-in m ks v)))
 
 (defn assoc-in-after
-  "Inserts `v` into `ks` after `before-ks` in `omap`"
+  "Inserts `v` into `ks` after `before-ks` in `omap`.
+`omap` is a nested associative structure, especially a map that can keep the order: `array-map`, [ordered-map](https://github.com/clj-commons/ordered), etc.
+`array-map` cannot keep the order when there are many elements, so in that case, please consider using `ordered-map` etc.
+`v` is new value, `ks` and `before-ks` are sequences of keys."
   [omap ks v before-ks]
   (let [empty-omap (empty omap)]
     (cond

--- a/src/cljc/proton/assoc_in_after.cljc
+++ b/src/cljc/proton/assoc_in_after.cljc
@@ -12,28 +12,29 @@
 (defn assoc-in-after
   "Inserts `v` into `ks` after `before-ks` in `omap`"
   [omap ks v before-ks]
-  (cond
-    (empty? ks) v
-    (empty? before-ks) (assoc-in* omap ks v)
-    (contains-in? omap ks) (assoc-in* omap ks v)
-    (contains? omap (first ks)) (update omap
-                                        (first ks)
-                                        assoc-in-after
-                                        (rest ks)
-                                        v
-                                        (rest before-ks))
-    (= ::first (first before-ks)) (into (array-map)
-                                        (cons [(first ks)
-                                               (assoc-in* (array-map)
-                                                          (rest ks)
-                                                          v)]
-                                              (seq omap)))
-    (not (contains? omap (first before-ks))) (assoc-in* omap ks v)
-    :else (into (array-map)
-                (mapcat (fn [[k child]]
-                          (if (= (first before-ks) k)
-                            [[k child]
-                             [(first ks)
-                              (assoc-in* (array-map) (rest ks) v)]]
-                            [[k child]]))
-                        (seq omap)))))
+  (let [empty-omap (empty omap)]
+    (cond
+      (empty? ks) v
+      (empty? before-ks) (assoc-in* omap ks v)
+      (contains-in? omap ks) (assoc-in* omap ks v)
+      (contains? omap (first ks)) (update omap
+                                          (first ks)
+                                          assoc-in-after
+                                          (rest ks)
+                                          v
+                                          (rest before-ks))
+      (= ::first (first before-ks)) (into empty-omap
+                                          (cons [(first ks)
+                                                 (assoc-in* empty-omap
+                                                            (rest ks)
+                                                            v)]
+                                                (seq omap)))
+      (not (contains? omap (first before-ks))) (assoc-in* omap ks v)
+      :else (into empty-omap
+                  (mapcat (fn [[k child]]
+                            (if (= (first before-ks) k)
+                              [[k child]
+                               [(first ks)
+                                (assoc-in* empty-omap (rest ks) v)]]
+                              [[k child]]))
+                          (seq omap))))))

--- a/src/cljc/proton/diff.cljc
+++ b/src/cljc/proton/diff.cljc
@@ -2,8 +2,9 @@
   "Helpful diff functions like `diff -u`"
   (:require
    [clojure.data :refer [diff]]
-   [clojure.pprint :refer [pprint]]
-   [clojure.string :as string]))
+   [clojure.string :as string]
+   #?(:clj [clojure.pprint :refer [pprint]]
+      :cljs [cljs.pprint :refer [pprint]])))
 
 (defn- blank-padding [origin size]
   (into origin (take size (repeat ""))))

--- a/src/cljc/proton/diff_assert.cljc
+++ b/src/cljc/proton/diff_assert.cljc
@@ -1,9 +1,16 @@
 (ns proton.diff-assert
+  "`diff-u=` is helpful diff assertions.
+
+Useage `(is (diff-u= a b))`
+      
+When a and b don't equal, it shows diff by using `diff-u` function.
+This assertion doesn't support `cljs.test`, so you can use this on `clojure.test` only."
   #?(:clj (:require [clojure.test :as t]
                     [proton.diff :as diff])))
 
 #?(:clj
-   (defmethod t/assert-expr 'diff-u= [msg form]
+   (defmethod t/assert-expr 'diff-u=
+     [msg form]
      `(let [actual# ~(nth form 1)
             expected# ~(nth form 2)
             diff# (diff/diff-u actual# expected#)]

--- a/src/cljc/proton/diff_assert.cljc
+++ b/src/cljc/proton/diff_assert.cljc
@@ -1,15 +1,15 @@
 (ns proton.diff-assert
-  (:require #?(:clj [clojure.test :refer [assert-expr do-report]]
-               :cljs [cljs.test :refer-macros [assert-expr] :refer [do-report]])
-            [proton.diff :as diff]))
+  #?(:clj (:require [clojure.test :as t]
+                    [proton.diff :as diff])))
 
-(defmethod assert-expr 'diff-u= [msg form]
-  `(let [actual# ~(nth form 1)
-         expected# ~(nth form 2)
-         diff# (diff/diff-u actual# expected#)]
-     (if diff#
-       (do-report {:type :fail :message diff#
-                   :expected expected# :actual actual#})
-       (do-report {:type :pass :message ~msg
-                   :expected expected# :actual actual#}))
-     (not diff#)))
+#?(:clj
+   (defmethod t/assert-expr 'diff-u= [msg form]
+     `(let [actual# ~(nth form 1)
+            expected# ~(nth form 2)
+            diff# (diff/diff-u actual# expected#)]
+        (if diff#
+          (t/do-report {:type :fail :message diff#
+                        :expected expected# :actual actual#})
+          (t/do-report {:type :pass :message ~msg
+                        :expected expected# :actual actual#}))
+        (not diff#))))

--- a/test/proton/assoc_in_after_test.cljc
+++ b/test/proton/assoc_in_after_test.cljc
@@ -29,16 +29,16 @@
 
 (deftest assoc-in-after-test
   (testing "When `ks` is empty, it returns just `v`"
-    (is (= (aia/assoc-in-after {} [] 2 [])
+    (is (= (aia/assoc-in-after (array-map) [] 2 [])
            2)))
   (testing "When `before-ks` is empty, it's same `(assoc-in omap ks v)`"
-    (is (= (aia/assoc-in-after {:a {:b 1}} [:a :b] 2 [])
+    (is (= (aia/assoc-in-after (array-map :a {:b 1}) [:a :b] 2 [])
            {:a {:b 2}})))
   (testing "When `before-ks` isn't empty and `ks` is in `omap`, it's same `(assoc-in omap ks v)`"
-    (is (= (aia/assoc-in-after {:a {:b 1}} [:a :b] 2 [:a])
+    (is (= (aia/assoc-in-after (array-map :a {:b 1}) [:a :b] 2 [:a])
            {:a {:b 2}})))
   (testing "When the first of `ks` is in `omap`, it inserts `v` into `ks` after `before-ks`"
-    (is (= (aia/assoc-in-after {:a {:b 1 :d 3}} [:a :c] 2 [:a :b])
+    (is (= (aia/assoc-in-after (array-map :a {:b 1 :d 3}) [:a :c] 2 [:a :b])
            {:a {:b 1 :c 2 :d 3}})))
   (testing "When `before-ks` is `[:proton.assoc-in-after/first]`, it inserts `{ks v}` into the first of `omap`"
     (let [target (aia/assoc-in-after (array-map :a {:b 1}) [:c] 2 [:proton.assoc-in-after/first])]
@@ -47,13 +47,13 @@
       (is (= (first target)
              [:c 2]))))
   (testing "When the first of `before-ks` is not in `omap`, it inserts `{ks v}` into the last of `omap`"
-    (let [target (aia/assoc-in-after {:a {:b 1}} [:c] 2 [:b])]
+    (let [target (aia/assoc-in-after (array-map :a {:b 1}) [:c] 2 [:b])]
       (is (= target
              {:a {:b 1} :c 2}))
       (is (= (last target)
              [:c 2]))))
   (testing "When the first of `before-ks` is in `omap`, it inserts `{ks v}` after `before-ks`"
-    (let [target (aia/assoc-in-after {:a {:b 1} :d 3} [:c] 2 [:a])]
+    (let [target (aia/assoc-in-after (array-map :a {:b 1} :d 3) [:c] 2 [:a])]
       (is (= target
              {:a {:b 1} :c 2 :d 3}))
       (is (= (second target)

--- a/test/proton/assoc_in_after_test.cljc
+++ b/test/proton/assoc_in_after_test.cljc
@@ -1,0 +1,60 @@
+(ns proton.assoc-in-after-test
+  (:require #?(:clj [clojure.test :refer [is are deftest testing]]
+               :cljs [cljs.test :refer-macros [is are deftest testing]])
+            [proton.assoc-in-after :as aia]))
+
+(deftest contains-in?-test
+  (are [m ks r] (= (#'aia/contains-in? m ks)
+                   r)
+    {:a {:b 1}}
+    [:a :b]
+    true
+
+    {:a {:b 1}}
+    [:a :c]
+    false))
+
+(deftest assoc-in*-test
+  (are [m ks v r] (= (#'aia/assoc-in* m ks v)
+                     r)
+    {:a {:b 1}}
+    [:a :b]
+    2
+    {:a {:b 2}}
+
+    {:a {:b 1}}
+    []
+    2
+    2))
+
+(deftest assoc-in-after-test
+  (testing "When `ks` is empty, it returns just `v`"
+    (is (= (aia/assoc-in-after {} [] 2 [])
+           2)))
+  (testing "When `before-ks` is empty, it's same `(assoc-in omap ks v)`"
+    (is (= (aia/assoc-in-after {:a {:b 1}} [:a :b] 2 [])
+           {:a {:b 2}})))
+  (testing "When `before-ks` isn't empty and `ks` is in `omap`, it's same `(assoc-in omap ks v)`"
+    (is (= (aia/assoc-in-after {:a {:b 1}} [:a :b] 2 [:a])
+           {:a {:b 2}})))
+  (testing "When the first of `ks` is in `omap`, it inserts `v` into `ks` after `before-ks`"
+    (is (= (aia/assoc-in-after {:a {:b 1 :d 3}} [:a :c] 2 [:a :b])
+           {:a {:b 1 :c 2 :d 3}})))
+  (testing "When `before-ks` is `[:proton.assoc-in-after/first]`, it inserts `{ks v}` into the first of `omap`"
+    (let [target (aia/assoc-in-after (array-map :a {:b 1}) [:c] 2 [:proton.assoc-in-after/first])]
+      (is (= target
+             {:c 2 :a {:b 1}}))
+      (is (= (first target)
+             [:c 2]))))
+  (testing "When the first of `before-ks` is not in `omap`, it inserts `{ks v}` into the last of `omap`"
+    (let [target (aia/assoc-in-after {:a {:b 1}} [:c] 2 [:b])]
+      (is (= target
+             {:a {:b 1} :c 2}))
+      (is (= (last target)
+             [:c 2]))))
+  (testing "When the first of `before-ks` is in `omap`, it inserts `{ks v}` after `before-ks`"
+    (let [target (aia/assoc-in-after {:a {:b 1} :d 3} [:c] 2 [:a])]
+      (is (= target
+             {:a {:b 1} :c 2 :d 3}))
+      (is (= (second target)
+             [:c 2])))))

--- a/test/proton/diff_assert_test.cljc
+++ b/test/proton/diff_assert_test.cljc
@@ -1,9 +1,8 @@
 (ns proton.diff-assert-test
-  #?(:clj (:require [clojure.test :refer [is deftest testing]]
-                    [proton.diff-assert])
-     :cljs (:require-macros [cljs.test :refer [is deftest testing]]
-                            [proton.diff-assert])))
+  #?(:clj (:require [clojure.test :as t]
+                    [proton.diff-assert])))
 
-(deftest diff-assert-test
-  (testing "diff-u= assert"
-    (is (diff-u= {:a 1} {:a 1}))))
+#?(:clj
+   (t/deftest diff-assert-test
+     (t/testing "diff-u= assert"
+       (t/is (diff-u= {:a 1} {:a 1})))))

--- a/test/proton/test.cljs
+++ b/test/proton/test.cljs
@@ -5,7 +5,8 @@
             [proton.pattern-test]
             [proton.string-test]
             ;; [proton.time-test]
-            [proton.uri-test]))
+            [proton.uri-test]
+            [proton.diff-test]))
 
 (enable-console-print!)
 


### PR DESCRIPTION
`(assoc-in-after omap ks v before-ks)`

Insert a `v` into `ks` after `before-ks` in `omap`. `omap` is an array-map, `ks` is a sequence of keys, `v` is the new value and `before-ks` is a sequence of keys which decides the position to insert. 

