### PR TITLE
Add lcomp and lcomp-apply

### DIFF
--- a/src/cljc/proton/function.cljc
+++ b/src/cljc/proton/function.cljc
@@ -1,0 +1,17 @@
+(ns proton.function)
+
+(defn comp->
+  "Apply comp from left to right"
+  [& fs]
+  (apply comp (reverse fs)))
+
+(defn step->
+  "Apply the composition of fs from left to right"
+  ([init-val f & fs]
+   (step-> init-val (cons f fs)))
+  ([init-val fs]
+   (if (fn? fs)
+     (fs init-val)
+     (if (seq fs)
+       ((apply comp-> fs) init-val)
+       init-val))))

--- a/src/cljc/proton/function.cljc
+++ b/src/cljc/proton/function.cljc
@@ -5,14 +5,14 @@
   [& fs]
   (apply comp (reverse fs)))
 
-;; TODO can pass "options" (I had better use "reduce"?)
+(defn- apply-fs [init-val fs run-fn]
+  (if (seq fs)
+    (reduce run-fn init-val fs)
+    init-val))
+
 (defn lcomp-apply
   "Apply the composition of fs from left to right"
-  ([init-val f & fs]
-   (lcomp-apply init-val (cons f fs)))
   ([init-val fs]
-   (if (fn? fs)
-     (fs init-val)
-     (if (seq fs)
-       ((apply lcomp fs) init-val)
-       init-val))))
+   (apply-fs init-val fs #(%2 %1)))
+  ([init-val fs opts]
+   (apply-fs init-val fs #(%2 %1 opts))))

--- a/src/cljc/proton/function.cljc
+++ b/src/cljc/proton/function.cljc
@@ -1,17 +1,18 @@
 (ns proton.function)
 
-(defn comp->
+(defn lcomp
   "Apply comp from left to right"
   [& fs]
   (apply comp (reverse fs)))
 
-(defn step->
+;; TODO can pass "options" (I had better use "reduce"?)
+(defn lcomp-apply
   "Apply the composition of fs from left to right"
   ([init-val f & fs]
-   (step-> init-val (cons f fs)))
+   (lcomp-apply init-val (cons f fs)))
   ([init-val fs]
    (if (fn? fs)
      (fs init-val)
      (if (seq fs)
-       ((apply comp-> fs) init-val)
+       ((apply lcomp fs) init-val)
        init-val))))

--- a/test/proton/function_test.cljc
+++ b/test/proton/function_test.cljc
@@ -3,11 +3,11 @@
                :cljs [cljs.test :refer-macros [deftest is]])
             [proton.function :as function]))
 
-(deftest comp->-test
+(deftest lcomp-test
   (is (= ((comp (partial * 2) inc) 8) 18))
-  (is (= ((function/comp-> inc (partial * 2)) 8) 18)))
+  (is (= ((function/lcomp inc (partial * 2)) 8) 18)))
 
-(deftest step->-test
-  (is (= (function/step-> 8 inc) 9))
-  (is (= (function/step-> 8 inc (partial * 2)) 18))
-  (is (= (function/step-> 8 [inc (partial * 2)]) 18)))
+(deftest lcomp-apply-test
+  (is (= (function/lcomp-apply 8 inc) 9))
+  (is (= (function/lcomp-apply 8 inc (partial * 2)) 18))
+  (is (= (function/lcomp-apply 8 [inc (partial * 2)]) 18)))

--- a/test/proton/function_test.cljc
+++ b/test/proton/function_test.cljc
@@ -8,6 +8,7 @@
   (is (= ((function/lcomp inc (partial * 2)) 8) 18)))
 
 (deftest lcomp-apply-test
-  (is (= (function/lcomp-apply 8 inc) 9))
-  (is (= (function/lcomp-apply 8 inc (partial * 2)) 18))
-  (is (= (function/lcomp-apply 8 [inc (partial * 2)]) 18)))
+  (is (= (function/lcomp-apply 8 [inc]) 9))
+  (is (= (function/lcomp-apply 8 [inc (partial * 2)]) 18))
+  (is (= (function/lcomp-apply 8 [(fn [n opts] (if (:twice opts) (* n 2) n))] {:twice true}) 16))
+  (is (= (function/lcomp-apply 8 [(fn [n opts] (if (:twice opts) (* n 2) n))] {}) 8)))

--- a/test/proton/function_test.cljc
+++ b/test/proton/function_test.cljc
@@ -1,0 +1,13 @@
+(ns proton.function-test
+  (:require #?(:clj [clojure.test :refer [deftest is]]
+               :cljs [cljs.test :refer-macros [deftest is]])
+            [proton.function :as function]))
+
+(deftest comp->-test
+  (is (= ((comp - /) 8 3) -8/3))
+  (is (= ((function/comp-> / -) 8 3) -8/3)))
+
+(deftest step->-test
+  (is (= (function/step-> 8 inc) 9))
+  (is (= (function/step-> 8 inc (partial * 2)) 18))
+  (is (= (function/step-> 8 [inc (partial * 2)]) 18)))

--- a/test/proton/function_test.cljc
+++ b/test/proton/function_test.cljc
@@ -4,8 +4,8 @@
             [proton.function :as function]))
 
 (deftest comp->-test
-  (is (= ((comp - /) 8 3) -8/3))
-  (is (= ((function/comp-> / -) 8 3) -8/3)))
+  (is (= ((comp (partial * 2) inc) 8) 18))
+  (is (= ((function/comp-> inc (partial * 2)) 8) 18)))
 
 (deftest step->-test
   (is (= (function/step-> 8 inc) 9))


### PR DESCRIPTION
I added comp-> and step-> functions

### lcomp

This is comp function which applies functions left-to-right order.
Next two codes return same function:

```clojure
(comp - /)
(lcomp / -)
```

### lcomp-apply

```
(c (b (a x)))
```

This can convert next:

```
(lcomp-apply x [a b c])
```
