### PR TITLE
Assert as-*'s arguments using defn prepost-map

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -9,23 +9,12 @@
   (-> s
       (string/replace #"," "")))
 
-(defn- string?! [s]
-  (cond
-    (nil? s)
-    false
-
-    (string? s)
-    true
-
-    :else
-    (throw (#?(:clj (IllegalArgumentException. "An argument should be string")
-               :cljs (js/Error. "An argument should be string"))))))
-
 (defn as-long
   "Returns a new long number initialized to the value represented by s.
   as-int returns nil if s is an illegal string or nil."
   [s]
-  (when (string?! s)
+  {:pre [(or (nil? s) (string? s))]}
+  (when-not (nil? s)
     (let [[n _ _] (re-matches #"(|-|\+)(\d+)" (sanitize-number-string s))]
       (when-not (nil? n)
         (try
@@ -40,7 +29,8 @@
   as-int returns nil if s is an illegal string or nil. as-long returns a
   long number if s is out of int range."
   [s]
-  (when (string?! s)
+  {:pre [(or (nil? s) (string? s))]}
+  (when-not (nil? s)
     (let [[n _ _] (re-matches #"(|-|\+)(\d+)" (sanitize-number-string s))]
       (when-not (nil? n)
         (try
@@ -56,7 +46,8 @@
   "Returns a new double number initialized to the value represented by s.
   as-double returns nil if s is an illegal string or nil."
   [s]
-  (when (string?! s)
+  {:pre [(or (nil? s) (string? s))]}
+  (when-not (nil? s)
     (when-let [[n] (re-matches #"[\-\+]?\d+(\.\d+)?([eE][\-\+]?\d+)?" (sanitize-number-string s))]
       (try
         #?(:clj (Double/parseDouble n)
@@ -70,7 +61,8 @@
   as-float returns nil if s is an illegal string or nil. as-float returns a
   double number if s is out of float range."
   [s]
-  (when (string?! s)
+  {:pre [(or (nil? s) (string? s))]}
+  (when-not (nil? s)
     (when-let [[n] (re-matches #"[\-\+]?\d+(\.\d+)?([eE][\-\+]?\d+)?" (sanitize-number-string s))]
       (try
         #?(:clj (let [r (Float/parseFloat n)]
@@ -87,7 +79,8 @@
   as \"1\", \"1/2\", and \"-1/2\". as-rational returns nil if s is an illegal
   string, nil, or division by zero."
   [s]
-  (when (string?! s)
+  {:pre [(or (nil? s) (string? s))]}
+  (when-not (nil? s)
     (when-let [[_ n _ d] (re-matches #"([\-\+]?\d+)(/(\d+))?" (sanitize-number-string s))]
       (try
         (let [numerator ^long (as-long n)
@@ -103,7 +96,8 @@
   "Returns a boolean represented by s. as-boolean returns true if s is \"true\"
   or \"yes\", ignoring case, false if \"false\" or \"no\", and nil otherwise."
   [s]
-  (when (string?! s)
+  {:pre [(or (nil? s) (string? s))]}
+  (when-not (nil? s)
     (condp re-matches s
       #"(?i)(true|yes)" true
       #"(?i)(false|no)" false

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -15,6 +15,11 @@
     "abc"
     ""
     nil)
+  (are [s] (thrown? #?(:clj AssertionError :cljs js/Error) (core/as-long s))
+    123
+    9.87
+    {:foo "bar"}
+    [1 2 3])
   (testing "different between clj and cljs"
     (is (= (core/as-long "292999988888999999888888")
            #?(:clj nil :cljs 292999988888999999888888)))))
@@ -31,6 +36,11 @@
     "abc"
     ""
     nil)
+  (are [s] (thrown? #?(:clj AssertionError :cljs js/Error) (core/as-int s))
+    123
+    9.87
+    {:foo "bar"}
+    [1 2 3])
   (testing "different between clj and cljs"
     (is (= (core/as-int "292999988888999999888888")
            #?(:clj nil :cljs 292999988888999999888888)))))
@@ -47,7 +57,12 @@
     "1.23.45"
     "abc"
     ""
-    nil))
+    nil)
+  (are [s] (thrown? #?(:clj AssertionError :cljs js/Error) (core/as-double s))
+    123
+    9.87
+    {:foo "bar"}
+    [1 2 3]))
 
 (deftest as-float-test
   (are [s e] (= (core/as-float s) e)
@@ -60,7 +75,12 @@
   (are [s] (nil? (core/as-float s))
     "abc"
     ""
-    nil))
+    nil)
+  (are [s] (thrown? #?(:clj AssertionError :cljs js/Error) (core/as-float s))
+    123
+    9.87
+    {:foo "bar"}
+    [1 2 3]))
 
 (deftest as-rational-test
   (are [s e] (= (core/as-rational s) e)
@@ -79,7 +99,12 @@
     ""
     nil
     "2/0"
-    "-2/0"))
+    "-2/0")
+  (are [s] (thrown? #?(:clj AssertionError :cljs js/Error) (core/as-rational s))
+    #?(:clj 1/2 :cljs 0.5)
+    1.5
+    {:foo "bar"}
+    [1 2 3]))
 
 (deftest as-boolean-test
   (are [s] (true? (core/as-boolean s))
@@ -95,7 +120,13 @@
   (are [s] (nil? (core/as-boolean s))
     "0"
     ""
-    nil))
+    nil)
+  (are [s] (thrown? #?(:clj AssertionError :cljs js/Error) (core/as-boolean s))
+    true
+    false
+    123
+    {:foo "bar"}
+    [1 2 3]))
 
 (deftest is-uuid?-test
   (is (not (core/is-uuid? 1)))


### PR DESCRIPTION
According to #17, I have refactored `as-*` function's argument validation using `defn`'s prepost-map then addded more test cases for them.