### PR TITLE
Fix to prevent errors occuring when merging non-map value

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -198,7 +198,7 @@
   "Recursively merges maps."
   [& maps]
   (letfn [(m [& xs]
-            (if (some #(and (map? %) (not (record? %))) xs)
+            (if (every? #(and (map? %) (not (record? %))) xs)
               (apply merge-with m xs)
               (last xs)))]
     (reduce m maps)))

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -161,4 +161,6 @@
   (is (= (core/deep-merge {:foo {:bar 1}} {:foo {:baz 2}})
          {:foo {:bar 1 :baz 2}}))
   (is (= (core/deep-merge {:foo {:bar 1}} {:baz 2})
-         {:foo {:bar 1} :baz 2})))
+         {:foo {:bar 1} :baz 2}))
+  (is (= (core/deep-merge {:foo 1} {:foo {:baz 2}})
+         {:foo {:baz 2}})))


### PR DESCRIPTION
In situation overriding non-map value to a map, the `merge-with` function throws an exception like below:

```clojure
(proton.core/deep-merge {:foo 1} {:foo {:bar :buzz}})
Execution error (IllegalArgumentException) at proton.core$deep_merge$m__4759/doInvoke (core.cljc:196).
contains? not supported on type: java.lang.Long
```

I assume the expected behavior is returning `{:foo {:bar :buzz}}` right?

In this PR, the `deep-merge` fn gets fix to pass only map values to the `merge-with` fn.
I also confirmed the tests passed.