### PR TITLE
Fix deep-merge with nil arguments and values

### DIFF
--- a/src/cljc/proton/core.cljc
+++ b/src/cljc/proton/core.cljc
@@ -198,7 +198,8 @@
   "Recursively merges maps."
   [& maps]
   (letfn [(m [& xs]
-            (if (every? #(and (map? %) (not (record? %))) xs)
-              (apply merge-with m xs)
-              (last xs)))]
+            (let [xs (remove nil? xs)]
+              (if (every? #(and (map? %) (not (record? %))) xs)
+                (apply merge-with m xs)
+                (last xs))))]
     (reduce m maps)))

--- a/test/proton/core_test.cljc
+++ b/test/proton/core_test.cljc
@@ -158,6 +158,14 @@
     nil 3 7))
 
 (deftest deep-merge-test
+  (is (= (core/deep-merge {:foo 1} nil)
+         {:foo 1}))
+  (is (= (core/deep-merge nil {:foo 1})
+         {:foo 1}))
+  (is (= (core/deep-merge {:foo 1} {:foo nil})
+         {:foo 1}))
+  (is (= (core/deep-merge {:foo nil} {:foo 1})
+         {:foo 1}))
   (is (= (core/deep-merge {:foo {:bar 1}} {:foo {:baz 2}})
          {:foo {:bar 1 :baz 2}}))
   (is (= (core/deep-merge {:foo {:bar 1}} {:baz 2})


### PR DESCRIPTION
I corrected the behavior of the deep-merge function for `nil` arguments and `nil` values in a map. Here's what I did:

```clj
(deep-merge {:foo 1} nil)        ;; => {:foo 1}
(deep-merge nil {:foo 1})        ;; => {:foo 1}
(deep-merge {:foo 1} {:foo nil}) ;; => {:foo 1}
(deep-merge {:foo nil} {:foo 1}) ;; => {:foo 1}
```
